### PR TITLE
Add workflow to automatically sync all tags from upstream to our fork

### DIFF
--- a/.github/workflows/sync-upstream-tags.yml
+++ b/.github/workflows/sync-upstream-tags.yml
@@ -1,0 +1,35 @@
+name: Sync Upstream Tags
+
+on:
+  schedule:
+    - cron: '0 * * * *' # every hour
+  workflow_dispatch:
+
+jobs:
+  sync-tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/anza-xyz/agave.git
+          git fetch upstream --tags
+
+      - name: Sync new tags
+        run: |
+          for tag in $(git tag -l --remote upstream | sed 's|upstream/||'); do
+            if ! git tag -l | grep -q "^$tag$"; then
+              git fetch upstream tag $tag
+              git tag $tag upstream/$tag
+              git push origin $tag
+            fi
+          done 


### PR DESCRIPTION
## Add GitHub Actions Workflow to Sync Upstream Tags

### Summary

This PR adds a GitHub Actions workflow (`sync-upstream-tags.yml`) that automatically syncs all tags from the upstream `anza-xyz/agave` repository to this fork. The workflow runs on a schedule (every hour) and can also be triggered manually.

### Details

- **Purpose:**  
  To ensure our fork always has the latest tags from upstream, making it easy to re-ship the same code and allow our Ansible playbooks to fetch sources from our fork instead of the original repo.
- **How it works:**  
  - Adds the upstream remote.
  - Fetches all tags from upstream.
  - Pushes any new tags to this fork.
- **No code changes or patches are applied yet**—this is a 1:1 sync of tags and code.
- **Next steps:**  
  - Once this is in place, we will add a step to automatically create GitHub Releases for each tag.
  - In a near future, we will add patching logic as needed.

This sets up the foundation for our team to:
- Seamlessly re-ship upstream releases under our own fork.
- Prepare for future modifications/patches.
- Minimize changes to our Ansible playbooks (just update the repo URL).